### PR TITLE
Adding RunOptimize function and improving tests...

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -54,6 +54,11 @@ func (rb *Bitmap) ReadFrom(stream io.Reader) (int64, error) {
 	return rb.highlowcontainer.readFrom(stream)
 }
 
+// RunOptimize attempts to further compress the runs of consecutive values found in the bitmap
+func (rb *Bitmap) RunOptimize() {
+	rb.highlowcontainer.runOptimize()
+}
+
 // ReadFromMsgpack reads a msgpack2/snappy-streaming serialized
 // version of this bitmap from stream
 func (rb *Bitmap) ReadFromMsgpack(stream io.Reader) (int64, error) {

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -70,6 +70,10 @@ func TestStringer(t *testing.T) {
 	if v.String() != "{0,1,2,3,4,5,6,7,8,9}" {
 		t.Error("bad string output")
 	}
+	v.RunOptimize()
+	if v.String() != "{0,1,2,3,4,5,6,7,8,9}" {
+		t.Error("bad string output")
+	}
 }
 
 func TestFastCard(t *testing.T) {
@@ -79,6 +83,13 @@ func TestFastCard(t *testing.T) {
 		bm.AddRange(21, 260000)
 		bm2 := NewBitmap()
 		bm2.Add(25)
+		So(bm2.AndCardinality(bm), ShouldEqual, 1)
+		So(bm2.OrCardinality(bm), ShouldEqual, bm.GetCardinality())
+		So(bm.AndCardinality(bm2), ShouldEqual, 1)
+		So(bm.OrCardinality(bm2), ShouldEqual, bm.GetCardinality())
+		So(bm2.AndCardinality(bm), ShouldEqual, 1)
+		So(bm2.OrCardinality(bm), ShouldEqual, bm.GetCardinality())
+		bm.RunOptimize()
 		So(bm2.AndCardinality(bm), ShouldEqual, 1)
 		So(bm2.OrCardinality(bm), ShouldEqual, bm.GetCardinality())
 		So(bm.AndCardinality(bm2), ShouldEqual, 1)

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -152,6 +152,64 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 	}
 }
 
+func TestSerializationFromJava(t *testing.T) {
+	fname := "testdata/bitmapwithoutruns.bin"
+	newrb := NewBitmap()
+	fin, err := os.Open(fname)
+
+	if err != nil {
+		t.Errorf("Failed reading")
+	}
+	defer func() {
+		fin.Close()
+	}()
+	_, _ = newrb.ReadFrom(fin)
+	fmt.Println(newrb.GetCardinality())
+	rb := NewBitmap()
+	for k := uint32(0); k < 100000; k += 1000 {
+		rb.Add(k)
+	}
+	for k := uint32(100000); k < 200000; k++ {
+		rb.Add(3 * k)
+	}
+	for k := uint32(700000); k < 800000; k++ {
+		rb.Add(k)
+	}
+	fmt.Println(rb.GetCardinality())
+	if !rb.Equals(newrb) {
+		t.Errorf("Bad serialization")
+	}
+
+}
+
+func TestSerializationFromJavaWithRuns(t *testing.T) {
+	fname := "testdata/bitmapwithruns.bin"
+	newrb := NewBitmap()
+	fin, err := os.Open(fname)
+
+	if err != nil {
+		t.Errorf("Failed reading")
+	}
+	defer func() {
+		fin.Close()
+	}()
+	_, _ = newrb.ReadFrom(fin)
+	rb := NewBitmap()
+	for k := uint32(0); k < 100000; k += 1000 {
+		rb.Add(k)
+	}
+	for k := uint32(100000); k < 200000; k++ {
+		rb.Add(3 * k)
+	}
+	for k := uint32(700000); k < 800000; k++ {
+		rb.Add(k)
+	}
+	if !rb.Equals(newrb) {
+		t.Errorf("Bad serialization")
+	}
+
+}
+
 func TestSerializationBasic2_041(t *testing.T) {
 
 	rb := BitmapOf(1, 2, 3, 4, 5, 100, 1000, 10000, 100000, 1000000)

--- a/smat.go
+++ b/smat.go
@@ -56,7 +56,6 @@ the workdir where you should be able to find the panic goroutine stack
 traces.
 */
 
-
 package roaring
 
 import (
@@ -124,6 +123,7 @@ var smatActionMap = smat.ActionMap{
 	smat.ActionID('A'): smatAction(" andCardinality", smatWrap(smatAndCardinality)),
 
 	smat.ActionID('c'): smatAction(" clear", smatWrap(smatClear)),
+	smat.ActionID('r'): smatAction(" runOptimize", smatWrap(smatRunOptimize)),
 
 	smat.ActionID('e'): smatAction(" isEmpty", smatWrap(smatIsEmpty)),
 
@@ -279,6 +279,13 @@ func smatOrCardinality(c *smatContext) {
 			px.checkEquals()
 			py.checkEquals()
 		})
+	})
+}
+
+func smatRunOptimize(c *smatContext) {
+	c.withPair(c.x, func(px *smatPair) {
+		px.bm.RunOptimize()
+		px.checkEquals()
 	})
 }
 


### PR DESCRIPTION
1. Adding RunOptimize function,
2. Putting back the portable (Java+C) serialization test (they are failing---in the simplest case, the array contain has garbage instead of the values {0,1000,2000,...} as expected),
3. Tweaking a fast-cardinality test (it seems to never complete),
4. Adding RunOptimize to the smat tests (hopefully, added it correctly).