### PR TITLE
Still hunting for bugs... 

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -312,7 +312,7 @@ func (ac *arrayContainer) ior(a container) container {
 	case *bitmapContainer:
 		return a.ior(ac)
 	case *runContainer16:
-		return x.iorArray(ac)
+		return x.orArray(ac) // alternative x.iorArray(ac) is unlikely to be correct
 	}
 	panic("unsupported container type")
 }
@@ -323,6 +323,9 @@ func (ac *arrayContainer) lazyIOR(a container) container {
 		return ac.lazyorArray(x)
 	case *bitmapContainer:
 		return a.lazyOR(ac)
+	case *runContainer16:
+		return x.orArray(ac)
+
 	}
 	panic("unsupported container type")
 }
@@ -333,6 +336,8 @@ func (ac *arrayContainer) lazyOR(a container) container {
 		return ac.lazyorArray(x)
 	case *bitmapContainer:
 		return a.lazyOR(ac)
+	case *runContainer16:
+		return x.orArray(ac)
 	}
 	panic("unsupported container type")
 }
@@ -423,7 +428,7 @@ func (ac *arrayContainer) iand(a container) container {
 	case *bitmapContainer:
 		return ac.iandBitmap(x)
 	case *runContainer16:
-		return x.iandArray(ac)
+		return x.andArray(ac) // alternative x.iandArray(ac) is unlikely to be correct
 	}
 	panic("unsupported container type")
 }
@@ -502,7 +507,7 @@ func (ac *arrayContainer) iandNot(a container) container {
 	case *bitmapContainer:
 		return ac.iandNotBitmap(x)
 	case *runContainer16:
-		return x.iandNotArray(ac)
+		return x.andNotArray(ac) // alternative is unlikely to be correct: x.iandNotArray(ac)
 	}
 	panic("unsupported container type")
 }

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -274,7 +274,8 @@ func (bc *bitmapContainer) ior(a container) container {
 	case *bitmapContainer:
 		return bc.iorBitmap(x)
 	case *runContainer16:
-		return x.iorBitmapContainer(bc)
+		// todo: implement fast function that sets entire ranges in the bitmap containers, current implementation is inefficient
+		return x.orBitmapContainer(bc) // the alternative x.iorBitmapContainer(bc) is unlikely to be correct since would modif. a
 	}
 	panic("unsupported container type")
 }
@@ -285,6 +286,8 @@ func (bc *bitmapContainer) lazyIOR(a container) container {
 		return bc.lazyIORArray(x)
 	case *bitmapContainer:
 		return bc.lazyIORBitmap(x)
+	case *runContainer16:
+		return x.orBitmapContainer(bc) // TODO : implement efficient in-place lazy OR to bitmap
 	}
 	panic("unsupported container type")
 }
@@ -295,6 +298,9 @@ func (bc *bitmapContainer) lazyOR(a container) container {
 		return bc.lazyORArray(x)
 	case *bitmapContainer:
 		return bc.lazyORBitmap(x)
+	case *runContainer16:
+		return x.orBitmapContainer(bc) // TODO: implement lazy OR
+
 	}
 	panic("unsupported container type")
 }
@@ -479,6 +485,8 @@ func (bc *bitmapContainer) iand(a container) container {
 		return bc.andArray(x)
 	case *bitmapContainer:
 		return bc.iandBitmap(x)
+	case *runContainer16:
+		return x.andBitmapContainer(bc) // TODO : implement fast in-place
 	}
 	panic("unsupported container type")
 }
@@ -733,7 +741,7 @@ func newBitmapContainerFromRun(rc *runContainer16) *bitmapContainer {
 	if len(rc.iv) == 1 {
 		return newBitmapContainerwithRange(int(rc.iv[0].start), int(rc.iv[0].last))
 	}
-	
+
 	bc := newBitmapContainer()
 	for i := range rc.iv {
 		bc.iaddRange(int(rc.iv[i].start), int(rc.iv[i].last)+1)

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -563,7 +563,7 @@ func (bc *bitmapContainer) andNot(a container) container {
 		return bc.andNotArray(x)
 	case *bitmapContainer:
 		return bc.andNotBitmap(x)
-	}
+	} // what happens if a is a run container?
 	panic("unsupported container type")
 }
 
@@ -575,7 +575,7 @@ func (bc *bitmapContainer) iandNot(a container) container {
 		return bc.andNotArray(x)
 	case *bitmapContainer:
 		return bc.iandNotBitmap(x)
-	}
+	}// what happens if a is a run container?
 	panic("unsupported container type")
 }
 

--- a/example_roaring_test.go
+++ b/example_roaring_test.go
@@ -103,5 +103,16 @@ func TestExample2_roaring(t *testing.T) {
 	if !r1.Equals(rb3) {
 		t.Errorf("union with large run should give back contained set")
 	}
-
+	rb1 := r1.Clone()
+	rb1.AndNot(rb3)
+	if !rb1.IsEmpty() {
+		t.Errorf("And not with large should clear...")
+	}
+	for i := uint32(0); i < 10000; i += 3 {
+		rb1.Add(i)
+	}
+	rb1.AndNot(rb3)
+	if rb1.GetCardinality() != 1 {
+		t.Errorf("Only the value 0 should survive the andNot")
+	}
 }

--- a/rlei_test.go
+++ b/rlei_test.go
@@ -1569,4 +1569,3 @@ func TestRle16RandomIaddRangeIremoveRange031(t *testing.T) {
 
 	})
 }
-

--- a/roaring.go
+++ b/roaring.go
@@ -140,7 +140,6 @@ func (rb *Bitmap) GetSerializedSizeInBytes() uint64 {
 	return rb.highlowcontainer.serializedSizeInBytes()
 }
 
-
 // BoundSerializedSizeInBytes returns an upper bound on the serialized size in bytes
 // assuming that one wants to store "cardinality" integers in [0, universe_size)
 func BoundSerializedSizeInBytes(cardinality uint64, universeSize uint64) uint64 {


### PR DESCRIPTION
Regarding the semantics of "inplace" operations such as ior, iand... They are definitively not symmetric. The host can be modified but the parametric container should be unchanged. Getting this wrong can cause nasty bugs. So I am proposing a few changes.

The lazy operations can simply fall back on standard operations, it is a performance issue...  but let us get the logic correct first.

I think I triggered a simple bug with an additional simple test which one can check with ``go test -run TestExample*``. It seems related to missing ``andNot`` and ``iandNot`` code paths. These omissions (?) should definitively trigger unit test failures... I don't understand... maybe we need to add more tests.